### PR TITLE
Improve Debug Console Access

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -18,6 +18,13 @@ class CfgPatches
 
 class CfgFunctions
 {
+    class A3 {
+        class Debug {
+            class isDebugConsoleAllowed {
+                file = "\1tac_admin\func\fn_isDebugConsoleAllowed.sqf";
+            };
+        };
+    };
 	class tac1_admin
 	{
 		class adminMenu

--- a/func/fn_isDebugConsoleAllowed.sqf
+++ b/func/fn_isDebugConsoleAllowed.sqf
@@ -1,0 +1,19 @@
+
+private _enableDebugConsole = 
+// 0 - not allowed
+// 1 - allowed for server host and logged in admin
+// 2 - allowed always
+[
+	"DebugConsole", 
+	getMissionConfigValue ["enableDebugConsole", 0]
+]
+call (missionNamespace getVariable "BIS_fnc_getParamValue");
+
+// IN ANY MODE
+if (_enableDebugConsole isEqualTo 2 || isServer) exitWith {true};
+
+private _localID = [] call tac1_admin_local_uid;
+if ((_localID in ([] call tac1_adminIDs)) or (serverCommandAvailable "#kick")) exitWith { true };
+
+false
+


### PR DESCRIPTION
- Due to changes in Arma 3 1.70 - Access to the debug console was restricted this tweak will re-enable debug access to whitelisted admins.